### PR TITLE
Enable input files to be passed in through the command line.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 ==================
-active_contraction
+Active Contraction
 ==================
 
 Active contraction 
@@ -7,27 +7,22 @@ Active contraction
 Building the example
 ====================
 
-Instructions on how to configure and build with CMake::
+This example can be configure and built with CMake using the following commands::
 
   git clone https://github.com/OpenCMISS-Examples/active_contraction.git
-  mkdir build
+  mkdir active_contraction-build
+  cd active_contraction-build
   cmake -DOpenCMISSLibs_DIR=/path/to/opencmisslib/install ../active_contraction
   make  # cmake --build . will also work here and is much more platform agnostic.
 
 Running the example
 ===================
 
-Explain how the example is run::
+To run the example execute the following commands (assumes current directory is the build directory from 'Building the example')::
 
-  cd build
-  ./src/fortran/active_contraction.F90
+  cd src/fortran
+  ./active_contraction
 
-or maybe it is a Python only example::
-
-  source /path/to/opencmisslibs/install/virtaul_environments/oclibs_venv_pyXY_release/bin/activate
-  python src/python/active_contraction.py
-
-where the XY in the path are the Python major and minor versions respectively.
 
 Prerequisites
 =============

--- a/src/fortran/active_contraction.F90
+++ b/src/fortran/active_contraction.F90
@@ -57,7 +57,7 @@ PROGRAM ActiveContractionExample
 
   INTEGER(CMISSIntg) :: EquationsSetIndex  
   INTEGER(CMISSIntg) :: NumberOfComputationalNodes,NumberOfDomains,ComputationalNodeNumber
-  INTEGER(CMISSIntg) :: D, E, N, I
+  INTEGER(CMISSIntg) :: D, E, N, I, num_args, ix
 
   REAL(CMISSRP) :: TMP
   REAL(CMISSRP), DIMENSION(1:7) :: COSTA_PARAMS =  [ 0.2, 30.0, 12.0, 14.0, 14.0, 10.0, 18.0 ] ! a bff bfs bfn bss bsn bnn
@@ -86,6 +86,8 @@ PROGRAM ActiveContractionExample
   TYPE(cmfe_NodesType) :: CMNodes
   TYPE(cmfe_ControlLoopType) :: ControlLoop
 
+  character(len=256), dimension(:), allocatable :: args
+
   !Generic CMISS variables
   INTEGER(CMISSIntg) :: Err
 
@@ -102,12 +104,27 @@ PROGRAM ActiveContractionExample
   CALL cmfe_ComputationalNodeNumberGet(ComputationalNodeNumber,Err)
 
 
-!  open(unit = 2, file = "./input/hollowcylq-221.in")
-!  open(unit = 3, file = "./input/hollowcylq-221.in.gpactiv")
-  open(unit = 2, file = "./lvq-842.in")
-  open(unit = 3, file = "./lvq-842.in.gpactiv")
-  call read_mesh(2, Elements, Nodes, DirichletConditions, Fibers)
-  call read_activation_times(3, ActivationTimes)
+  num_args = command_argument_count()
+  allocate(args(num_args))
+
+  DO ix = 1, num_args
+    CALL get_command_argument(ix,args(ix))
+  END DO
+
+  IF (num_args .gt. 0) THEN
+    open(unit = 2, file = args(1))
+  ELSE
+!   open(unit = 2, file = "./input/hollowcylq-221.in")
+    open(unit = 2, file = "./lvq-842.in")
+  ENDIF
+  IF (num_args .gt. 1) THEN
+    open(unit = 3, file = args(2))
+  ELSE
+!   open(unit = 3, file = "./input/hollowcylq-221.in.gpactiv")
+    open(unit = 3, file = "./lvq-842.in.gpactiv")
+  ENDIF
+  CALL read_mesh(2, Elements, Nodes, DirichletConditions, Fibers)
+  CALL read_activation_times(3, ActivationTimes)
   close(2)
   close(3)
 


### PR DESCRIPTION
Input files should be able to be passed in through the command line to enable greater flexibility when running the example.